### PR TITLE
Tagi OpenGraph image + description

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,8 @@
     <script src="assets/js/gen.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
     <link rel="stylesheet" href="assets/css/main.css">
-    <meta property=”og:image” content=”assets/img/screen.png” >
+    <meta property="og:image" content="assets/img/screen.png">
+    <meta property="og:description" content="Proponowane zaktualizowane pytania egzaminacyjne do egzaminu na świadectwo operatora urządzeń radiowych w służbie radiokomunikacyjnej amatorskiej">
 </head>
 
 <body>

--- a/kat_a/1.html
+++ b/kat_a/1.html
@@ -10,7 +10,8 @@
     <script src="../assets/js/gen.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
     <link rel="stylesheet" href="../assets/css/main.css">
-<meta property=”og:image” content=”../assets/img/screen.png” >
+    <meta property="og:image" content="../assets/img/screen.png">
+    <meta property="og:description" content="Proponowane zaktualizowane pytania egzaminacyjne do egzaminu na świadectwo operatora urządzeń radiowych w służbie radiokomunikacyjnej amatorskiej">
 </head>
 
 <body>

--- a/kat_a/2.html
+++ b/kat_a/2.html
@@ -10,7 +10,8 @@
     <script src="../assets/js/gen.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
     <link rel="stylesheet" href="../assets/css/main.css">
-<meta property=”og:image” content=”../assets/img/screen.png” >
+    <meta property="og:image" content="../assets/img/screen.png">
+    <meta property="og:description" content="Proponowane zaktualizowane pytania egzaminacyjne do egzaminu na świadectwo operatora urządzeń radiowych w służbie radiokomunikacyjnej amatorskiej">
 </head>
 
 <body>

--- a/kat_a/3.html
+++ b/kat_a/3.html
@@ -10,7 +10,8 @@
     <script src="../assets/js/gen.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
     <link rel="stylesheet" href="../assets/css/main.css">
-<meta property=”og:image” content=”../assets/img/screen.png” >
+    <meta property="og:image" content="../assets/img/screen.png">
+    <meta property="og:description" content="Proponowane zaktualizowane pytania egzaminacyjne do egzaminu na świadectwo operatora urządzeń radiowych w służbie radiokomunikacyjnej amatorskiej">
 </head>
 
 <body>

--- a/kat_a/4.html
+++ b/kat_a/4.html
@@ -11,7 +11,8 @@
     <script src="../assets/js/gen.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
     <link rel="stylesheet" href="../assets/css/main.css">
-<meta property=”og:image” content=”../assets/img/screen.png” >
+    <meta property="og:image" content="../assets/img/screen.png">
+    <meta property="og:description" content="Proponowane zaktualizowane pytania egzaminacyjne do egzaminu na świadectwo operatora urządzeń radiowych w służbie radiokomunikacyjnej amatorskiej">
 </head>
 
 <body>

--- a/kat_a/index.html
+++ b/kat_a/index.html
@@ -10,7 +10,8 @@
     <script src="../assets/js/gen.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
     <link rel="stylesheet" href="../assets/css/main.css">
-    <meta property=”og:image” content=”../assets/img/screen.png” >
+    <meta property="og:image" content="../assets/img/screen.png">
+    <meta property="og:description" content="Proponowane zaktualizowane pytania egzaminacyjne do egzaminu na świadectwo operatora urządzeń radiowych w służbie radiokomunikacyjnej amatorskiej">
 </head>
 
 <body>

--- a/kat_c/1.html
+++ b/kat_c/1.html
@@ -10,7 +10,8 @@
     <script src="../assets/js/gen.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
     <link rel="stylesheet" href="../assets/css/main.css">
-<meta property=”og:image” content=”../assets/img/screen.png” >
+    <meta property="og:image" content="../assets/img/screen.png">
+    <meta property="og:description" content="Proponowane zaktualizowane pytania egzaminacyjne do egzaminu na świadectwo operatora urządzeń radiowych w służbie radiokomunikacyjnej amatorskiej">
 </head>
 
 <body>

--- a/kat_c/2.html
+++ b/kat_c/2.html
@@ -10,7 +10,8 @@
     <script src="../assets/js/gen.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
     <link rel="stylesheet" href="../assets/css/main.css">
-<meta property=”og:image” content=”../assets/img/screen.png” >
+    <meta property="og:image" content="../assets/img/screen.png">
+    <meta property="og:description" content="Proponowane zaktualizowane pytania egzaminacyjne do egzaminu na świadectwo operatora urządzeń radiowych w służbie radiokomunikacyjnej amatorskiej">
 </head>
 
 <body>

--- a/kat_c/3.html
+++ b/kat_c/3.html
@@ -10,7 +10,8 @@
     <script src="../assets/js/gen.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
     <link rel="stylesheet" href="../assets/css/main.css">
-<meta property=”og:image” content=”../assets/img/screen.png” >
+    <meta property="og:image" content="../assets/img/screen.png">
+    <meta property="og:description" content="Proponowane zaktualizowane pytania egzaminacyjne do egzaminu na świadectwo operatora urządzeń radiowych w służbie radiokomunikacyjnej amatorskiej">
 </head>
 
 <body>

--- a/kat_c/4.html
+++ b/kat_c/4.html
@@ -11,7 +11,8 @@
     <script src="../assets/js/gen.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
     <link rel="stylesheet" href="../assets/css/main.css">
-<meta property=”og:image” content=”../assets/img/screen.png” >
+    <meta property="og:image" content="../assets/img/screen.png">
+    <meta property="og:description" content="Proponowane zaktualizowane pytania egzaminacyjne do egzaminu na świadectwo operatora urządzeń radiowych w służbie radiokomunikacyjnej amatorskiej">
 </head>
 
 <body>

--- a/kat_c/index.html
+++ b/kat_c/index.html
@@ -10,7 +10,8 @@
     <script src="../assets/js/gen.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
     <link rel="stylesheet" href="../assets/css/main.css">
-<meta property=”og:image” content=”../assets/img/screen.png” >
+    <meta property="og:image" content="../assets/img/screen.png">
+    <meta property="og:description" content="Proponowane zaktualizowane pytania egzaminacyjne do egzaminu na świadectwo operatora urządzeń radiowych w służbie radiokomunikacyjnej amatorskiej">
 </head>
 
 <body>


### PR DESCRIPTION
Naprawiłem `og:image`, miał w sobie złe znaki (`”` zamiast `"`).
Dorzuciłem `og:desciption` z tekstem z nagłówka strony, ale jeśli ktoś ma lepszy pomysł, to można zmienić