### PR TITLE
'Alpaka' -> 'Grafit'

### DIFF
--- a/kat_a/dzial1a.csv
+++ b/kat_a/dzial1a.csv
@@ -1,5 +1,5 @@
 id,pytanie,ilustracja,odpa,odpb,odpc
-1,"Który z poniższych materiałów jest dobrym izolatorem elektrycznym?",,"szkło","alpaka","krzem"
+1,"Który z poniższych materiałów jest dobrym izolatorem elektrycznym?",,"szkło","grafit","krzem"
 2,"Połączenie, w którym przez wszystkie elementy płynie ten sam prąd nazywamy połączeniem:",,"rezonansowym","szeregowym","równoległym"
 3,"Przez kondensator o impedancji 10 Ω płynie prąd przemienny o częstotliwości 50Hz i wartości 2A. Jaki będzie spadek napięcia na kondensatorze?",,"10 V","50 V","20 V"
 4,"Przez trzy równoległe rezystory 1 Ω, 2 Ω i 4 Ω płyną prądy odpowiednio 4 A, 2 A i 1A. Całkowite natężenie prądu płynącego w obwodzie to: ",,"4 A","1 A","7 A"

--- a/kat_c/dzial1c.csv
+++ b/kat_c/dzial1c.csv
@@ -1,5 +1,5 @@
 id,pytanie,ilustracja,odpa,odpb,odpc
-1,"Który z poniższych materiałów jest dobrym izolatorem elektrycznym?",,"szkło","alpaka","krzem"
+1,"Który z poniższych materiałów jest dobrym izolatorem elektrycznym?",,"szkło","grafit","krzem"
 2,"Połączenie, w którym przez wszystkie elementy płynie ten sam prąd nazywamy połączeniem:",,"rezonansowym","szeregowym","równoległym"
 3,"Przez trzy równoległe rezystory 1 Ω, 2 Ω i 4 Ω płyną prądy odpowiednio 4 A, 2 A i 1A. Całkowite natężenie prądu płynącego w obwodzie to: ",,"4 A","1 A","7 A"
 4,"Łącząc równolegle źródła napięcia powinno się:",,"łączyć źródła o tej samej wydajności prądowej","łączyć źródła tylko tego samego typu","zadbać by ich napięcia były jednakowe"


### PR DESCRIPTION
'Alpaka' zdaje się sprawiać trudności językowe. Zamiana na 'grafit'.