### PR TITLE
Dodanie styli do druku (@media print)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,4 +1,5 @@
-html,body {
+html,
+body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
     font-size: 14px;
     background: #F0F2F4;
@@ -14,15 +15,68 @@ html,body {
 }
 
 .ilustration {
-    width:100% !important;
+    width: 100% !important;
 }
 
 @media (min-width:769px) {
     .ilustration {
-        width:50% !important;
+        width: 50% !important;
     }
 }
 
 #questions {
     margin: 0.75rem;
+}
+
+@media print {
+
+    html,
+    body {
+        background-color: white !important;
+    }
+
+    .hero {
+        background-color: white !important;
+        background-image: none !important;
+        padding: 0 !important;
+        min-height: auto !important;
+    }
+
+    .hero-body {
+        padding: 0 !important;
+    }
+
+    .hero .title {
+        color: black !important;
+    }
+
+    .navbar,
+    .button {
+        display: none !important;
+    }
+
+    article {
+        margin-top: 0.5rem !important;
+        margin-bottom: 0.1rem !important;
+        break-inside: avoid !important;
+    }
+
+    h4 {
+        margin-bottom: 0.1rem !important;
+    }
+
+    hr {
+        display: none !important;
+    }
+
+    ol {
+        margin-top: 0.2rem !important;
+        margin-bottom: 0.2rem !important;
+    }
+
+    .box.content {
+        box-shadow: none !important;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+    }
 }


### PR DESCRIPTION
Ukrywa przyciski, ciemne tła, lekko zmniejsza marginesy.

<img width="1707" height="1352" alt="image" src="https://github.com/user-attachments/assets/ca353dca-e8fd-4fc0-98b1-18da090892e7" />
